### PR TITLE
Add production profile setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,17 @@ Utilice el perfil correspondiente (por ejemplo `local` o `dev`) configurado en l
 
 ## Configuración
 
-Los archivos en `src/main/resources` contienen propiedades para distintos entornos (`application-local.properties`, `application-dev.properties`, etc.). Ajuste estas propiedades según sus credenciales y entorno.
+Los archivos en `src/main/resources` contienen propiedades para distintos entornos (`application-local.properties`, `application-dev.properties`, `application-prod.properties`, etc.). Ajuste estas propiedades según sus credenciales y entorno. En producción se espera que defina las variables de entorno `JDBC_URL`, `DB_USERNAME` y `DB_PASSWORD` utilizadas en `application-prod.properties`.
 
 ## Estructura
 - `src/main/java` – código Java de la aplicación.
 - `src/main/resources` – configuraciones y recursos.
 
 ## Despliegue
-El artefacto generado se ubica en `target/marketplace-backend-0.0.1-SNAPSHOT.jar`. Puede ejecutarlo con `java -jar`.
+El artefacto generado se ubica en `target/marketplace-backend-0.0.1-SNAPSHOT.jar`. Para ejecutarlo en producción, utilice:
+
+```bash
+java -jar target/marketplace-backend-0.0.1-SNAPSHOT.jar --spring.profiles.active=prod
+```
+
+Asegúrese de que las variables de entorno mencionadas estén configuradas antes de iniciar la aplicación.

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,23 @@
+# ---------------------------------------------------------------------------
+# DATASOURCE PROD (perfil "prod")
+# ---------------------------------------------------------------------------
+spring.datasource.url=${JDBC_URL}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# Hikari
+spring.datasource.hikari.maximum-pool-size=20
+spring.datasource.hikari.minimum-idle=5
+spring.datasource.hikari.idle-timeout=60000
+spring.datasource.hikari.connection-timeout=30000
+
+# Allow uploads up to 10MB in prod
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB
+# -------------------------------
+# ENCODING (común)
+# -------------------------------
+server.servlet.encoding.charset=UTF-8
+server.servlet.encoding.enabled=true
+server.servlet.encoding.force=true


### PR DESCRIPTION
## Summary
- add `application-prod.properties` with environment-based datasource configuration
- document new production profile usage in README

## Testing
- `java -jar target/marketplace-backend-0.0.1-SNAPSHOT.jar --spring.profiles.active=prod` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_688c34ddd534833099da5fe61eabdb03