### PR TITLE
Change default profile to dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Puede iniciar la aplicación con:
 mvn spring-boot:run
 ```
 
-Utilice el perfil correspondiente (por ejemplo `local` o `dev`) configurado en los archivos de `src/main/resources`.
+Por defecto la aplicación se inicia con el perfil `dev`. Puede cambiarlo estableciendo la propiedad `spring.profiles.active` o la variable de entorno `SPRING_PROFILES_ACTIVE`.
 
 ## Configuración
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 # -------------------------------
 # Perfiles
 # -------------------------------
-spring.profiles.active=local
+spring.profiles.active=dev
 
 # -------------------------------
 # JPA / HIBERNATE (común)


### PR DESCRIPTION
## Summary
- set `dev` as the default Spring profile
- document default profile in README

## Testing
- `mvn -q package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688c433488c88330ad6fa44f39d6eaa7