### PR TITLE
Delete user images from S3 on user removal

### DIFF
--- a/src/main/java/Marketplace/repositories/IListingRepository.java
+++ b/src/main/java/Marketplace/repositories/IListingRepository.java
@@ -78,4 +78,7 @@ public interface IListingRepository extends JpaRepository<Listing, Integer> {
 
     @Query(value = "CALL GetListingCategories(:listingId)", nativeQuery = true)
     List<IListingCategoryDto> getListingCategories(@Param("listingId") Long listingId) throws SQLException;
+
+    @Query(value = "CALL GetUserImages(:userId)", nativeQuery = true)
+    List<String> getUserImages(@Param("userId") Long userId) throws SQLException;
 }

--- a/src/main/java/Marketplace/services/impl/UserServiceImpl.java
+++ b/src/main/java/Marketplace/services/impl/UserServiceImpl.java
@@ -4,17 +4,23 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import Marketplace.commons.dtos.ResponseDataDto;
 import Marketplace.commons.dtos.ResponseDto;
 import Marketplace.dtos.request.UserRequestDto;
 import Marketplace.models.User;
 import Marketplace.dtos.response.UserResponseDto;
+import Marketplace.repositories.IListingRepository;
 import Marketplace.repositories.IUserCUDRepository;
 import Marketplace.repositories.IUserRepository;
+import Marketplace.services.S3Service;
 import Marketplace.services.UserService;
 
 import java.sql.SQLException;
+import java.util.List;
 
 @Service
 public class UserServiceImpl implements UserService {
@@ -31,6 +37,12 @@ public class UserServiceImpl implements UserService {
 
     @Autowired
     private IUserRepository userRepository;
+
+    @Autowired
+    private IListingRepository listingRepository;
+
+    @Autowired
+    private S3Service s3Service;
 
     @Override
     public ResponseDto manageProfilePicture(Long userId, UserRequestDto request) throws SQLException {
@@ -55,9 +67,30 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional
     public ResponseDto deleteUser(Long userId) throws SQLException {
         log.info(LOG_TXT + DELETE_TXT + " UserId: {}", userId);
-        return userCUDRepository.deleteUser(userId.longValue());
+
+        List<String> images = listingRepository.getUserImages(userId);
+
+        ResponseDto resp = userCUDRepository.deleteUser(userId.longValue());
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                for (String url : images) {
+                    if (url != null) {
+                        try {
+                            s3Service.deleteFile(s3Service.extractKey(url));
+                        } catch (Exception ex) {
+                            log.error("Error deleting user image", ex);
+                        }
+                    }
+                }
+            }
+        });
+
+        return resp;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- remove user's listing images from S3 when deleting the user using existing `GetUserImages` stored procedure

## Testing
- `mvn -q -e -U test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.4)*

------
https://chatgpt.com/codex/tasks/task_e_688d723afeb883309122462b159c6a8b