### PR TITLE
Fix handling of multiple listing images

### DIFF
--- a/src/main/java/Marketplace/services/impl/ListingCUDServiceImpl.java
+++ b/src/main/java/Marketplace/services/impl/ListingCUDServiceImpl.java
@@ -111,7 +111,7 @@ public class ListingCUDServiceImpl implements ListingCUDService {
             String desiredUrl = finalAux[i]; // por defecto “lo que hay”
 
             // a) Si vino array de URLS → ese es el estado deseado (url o null)
-            if (reqUrls != null) {
+            if (reqUrls != null && i < reqUrls.size()) {
                 desiredUrl = reqUrls.get(i); // puede ser null
             }
 

--- a/src/main/java/Marketplace/services/impl/ListingServiceImpl.java
+++ b/src/main/java/Marketplace/services/impl/ListingServiceImpl.java
@@ -114,8 +114,12 @@ public class ListingServiceImpl implements ListingService {
 
                         // 2) Subir imágenes auxiliares (hasta 4)
                         if (images != null) {
-                                for (MultipartFile img : images) {
-                                        auxUrls.add(s3Service.uploadFile(img));
+                                int limit = Math.min(images.size(), 4);
+                                for (int i = 0; i < limit; i++) {
+                                        MultipartFile img = images.get(i);
+                                        if (img != null) {
+                                                auxUrls.add(s3Service.uploadFile(img));
+                                        }
                                 }
                         }
 


### PR DESCRIPTION
## Summary
- guard against index errors when saving listing auxiliary images
- ensure listing creation uploads only up to four auxiliary images

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.4)*

------
https://chatgpt.com/codex/tasks/task_e_688e980dde348330a7766e3ab086a717