### PR TITLE
Upload verification proofs to private S3

### DIFF
--- a/src/main/java/Marketplace/controllers/RegisterController.java
+++ b/src/main/java/Marketplace/controllers/RegisterController.java
@@ -51,7 +51,7 @@ public class RegisterController {
         // =======================================================
         @PostMapping(value = "/verifyEmail", headers = TextConstant.APPLICATION_JSON)
         public ResponseEntity<ResponseDto> verifyEmail(
-                        @RequestBody UserRequestDto request) throws SQLException {
+                        @RequestBody UserRequestDto request) throws SQLException, MessagingException {
 
                 log.info(LOG_TXT + VERIFY_EMAIL_TXT + " Verificando email.");
 

--- a/src/main/java/Marketplace/repositories/IAuthRepository.java
+++ b/src/main/java/Marketplace/repositories/IAuthRepository.java
@@ -14,8 +14,16 @@ public interface IAuthRepository extends JpaRepository<ResponseDto, Integer> {
     ResponseDto setEmailConfirmationToken(@Param("userId") Long userId,
                                           @Param("token") String token);
 
+    @Query(value = "CALL SaveVerificationPending(:userId, :message, :proofUrl)", nativeQuery = true)
+    ResponseDto saveVerificationPending(@Param("userId") Long userId,
+                                        @Param("message") String message,
+                                        @Param("proofUrl") String proofUrl);
+
     @Query(value = "CALL VerifyEmail(:token)", nativeQuery = true)
-    ResponseDto verifyEmail(@Param("token") String token);
+    Long verifyEmail(@Param("token") String token);
+
+    @Query(value = "CALL SaveVerificationProof(:userId)", nativeQuery = true)
+    ResponseDto saveVerificationProof(@Param("userId") Long userId);
 
     @Query(value = "CALL SetResetToken(:email, :token)", nativeQuery = true)
     ResponseDto setResetToken(@Param("email") String email,

--- a/src/main/java/Marketplace/services/EmailService.java
+++ b/src/main/java/Marketplace/services/EmailService.java
@@ -19,6 +19,8 @@ public interface EmailService {
         String imageFilename
     ) throws MessagingException, IOException;
 
+    void sendPendingVerificationEmail(User user) throws MessagingException;
+
     public void sendResidenceDecisionEmail(User user, boolean approved)
                         throws MessagingException;
 

--- a/src/main/java/Marketplace/services/RegisterService.java
+++ b/src/main/java/Marketplace/services/RegisterService.java
@@ -10,5 +10,5 @@ import jakarta.mail.MessagingException;
 
 public interface RegisterService {
     ResponseDto registerUser(UserRequestDto req) throws SQLException, MessagingException, IOException;
-    ResponseDto verifyEmail(UserRequestDto request) throws SQLException;
+    ResponseDto verifyEmail(UserRequestDto request) throws SQLException, MessagingException;
 }

--- a/src/main/java/Marketplace/services/S3Service.java
+++ b/src/main/java/Marketplace/services/S3Service.java
@@ -51,6 +51,28 @@ public class S3Service {
     }
 
     /**
+     * Sube un arreglo de bytes al bucket privado para pruebas de verificación.
+     * Retorna la URL del objeto subido.
+     */
+    public String uploadProof(byte[] data, String filename) throws IOException {
+        if (data == null || data.length == 0 || !StringUtils.hasText(filename)) {
+            throw new IllegalArgumentException("Archivo vacío o sin nombre");
+        }
+
+        String clean = filename.replaceAll("[\\s()]", "_");
+        String key = "verification-proofs/" + UUID.randomUUID() + "-" + clean;
+
+        s3.putObject(
+                PutObjectRequest.builder()
+                        .bucket(bucket)
+                        .key(key)
+                        .build(),
+                RequestBody.fromBytes(data));
+
+        return String.format("https://%s.s3.amazonaws.com/%s", bucket, key);
+    }
+
+    /**
      * Elimina un objeto del bucket dado su key.
      */
     public void deleteFile(String key) {

--- a/src/main/java/Marketplace/services/impl/EmailServiceImpl.java
+++ b/src/main/java/Marketplace/services/impl/EmailServiceImpl.java
@@ -134,6 +134,21 @@ public class EmailServiceImpl implements EmailService {
         }
 
         @Override
+        public void sendPendingVerificationEmail(User user) throws MessagingException {
+                MimeMessage msg = sender.createMimeMessage();
+                MimeMessageHelper h = new MimeMessageHelper(msg, true);
+                h.setFrom(FROM_EMAIL);
+                h.setTo("mpulitano1701@gmail.com");
+                h.setSubject("Nueva verificación pendiente – " + BRAND_NAME);
+
+                String inner = "<p><strong>Email:</strong> " + user.getEmail() + "</p>";
+
+                h.setText(wrapper("Prueba de residencia recibida", inner), true);
+
+                sender.send(msg);
+        }
+
+        @Override
         public void sendResidenceDecisionEmail(User user, boolean approved) throws MessagingException {
                 String title = approved ? "Residencia verificada" : "Residencia rechazada";
                 String decisionText = approved


### PR DESCRIPTION
## Summary
- save verification documents in private S3 bucket and record pending proofs
- notify admins after email confirmation and finalize proof records
- use user ID returned by email verification to send pending verification email
## Testing
- `mvn -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689527bd52b083309985489c74cb33a7