### PR TITLE
feat: allow multipart document in user registration

### DIFF
--- a/src/main/java/Marketplace/controllers/RegisterController.java
+++ b/src/main/java/Marketplace/controllers/RegisterController.java
@@ -9,8 +9,10 @@ import jakarta.mail.MessagingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -30,14 +32,15 @@ public class RegisterController {
         // =======================================================
         // 1) Registro de Usuario
         // =======================================================
-        @PostMapping(value = "/register", headers = TextConstant.APPLICATION_JSON)
+        @PostMapping(value = "/register", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
         public ResponseEntity<ResponseDto> registerUser(
-                        @RequestBody UserRequestDto request)
+                        @RequestPart("request") UserRequestDto request,
+                        @RequestPart(value = "document", required = false) MultipartFile document)
                         throws SQLException, MessagingException, IOException {
 
                 log.info(LOG_TXT + REGISTER_TXT + " Solicitud de registro recibida.");
 
-                ResponseDto serviceResponse = registerService.registerUser(request);
+                ResponseDto serviceResponse = registerService.registerUser(request, document);
 
                 log.info(LOG_TXT + REGISTER_TXT +
                                 " Registro completado. Code: {}, Description: {}",

--- a/src/main/java/Marketplace/services/RegisterService.java
+++ b/src/main/java/Marketplace/services/RegisterService.java
@@ -7,8 +7,10 @@ import java.sql.SQLException;
 import Marketplace.commons.dtos.ResponseDto;
 import Marketplace.dtos.request.UserRequestDto;
 import jakarta.mail.MessagingException;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface RegisterService {
-    ResponseDto registerUser(UserRequestDto req) throws SQLException, MessagingException, IOException;
+    ResponseDto registerUser(UserRequestDto req, MultipartFile document)
+            throws SQLException, MessagingException, IOException;
     ResponseDto verifyEmail(UserRequestDto request) throws SQLException, MessagingException;
 }


### PR DESCRIPTION
## Summary
- accept optional `document` file in `/register` endpoint
- handle uploaded document in registration service

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68955d4256948330b66003521312c84b