### PR TITLE
Store listing photos in private bucket with presigned URLs

### DIFF
--- a/src/main/java/Marketplace/services/impl/ListingCUDServiceImpl.java
+++ b/src/main/java/Marketplace/services/impl/ListingCUDServiceImpl.java
@@ -84,7 +84,7 @@ public class ListingCUDServiceImpl implements ListingCUDService {
         // Si viene archivo y es diferente al actual (por URL), sube y reemplaza
         if (mainImage != null) {
             // Si el archivo es diferente al actual (por nombre o checksum, aquí solo por URL)
-            String uploaded = s3Service.uploadPublic(mainImage);
+            String uploaded = s3Service.uploadPrivate(mainImage);
             if (!Objects.equals(uploaded, currentMain)) {
                 uploadedMain = uploaded;
                 if (currentMain != null) {
@@ -126,7 +126,7 @@ public class ListingCUDServiceImpl implements ListingCUDService {
                 if (finalAux[i] != null) {
                     deleteKeys.add(finalAux[i]);
                 }
-                desiredUrl = s3Service.uploadPublic(parts[i]);
+                desiredUrl = s3Service.uploadPrivate(parts[i]);
                 uploadedAux.add(desiredUrl);
             }
             // c) Sin archivo, pero desiredUrl == null y había algo → borrar
@@ -193,7 +193,7 @@ public class ListingCUDServiceImpl implements ListingCUDService {
             public void afterCommit() {
                 for (String url : keysForDeletion) {
                     try {
-                        s3Service.deletePublic(s3Service.extractKey(url));
+                        s3Service.deletePrivate(url);
                     } catch (Exception ex) {
                         log.error("Error deleting old image", ex);
                     }
@@ -205,14 +205,14 @@ public class ListingCUDServiceImpl implements ListingCUDService {
         } catch (Exception e) {
             if (uploadedMain != null) {
                 try {
-                    s3Service.deletePublic(s3Service.extractKey(uploadedMain));
+                    s3Service.deletePrivate(uploadedMain);
                 } catch (Exception ex) {
                     log.error("Error limpiando main image", ex);
                 }
             }
             for (String url : uploadedAux) {
                 try {
-                    s3Service.deletePublic(s3Service.extractKey(url));
+                    s3Service.deletePrivate(url);
                 } catch (Exception ex) {
                     log.error("Error limpiando aux image", ex);
                 }
@@ -241,13 +241,13 @@ public class ListingCUDServiceImpl implements ListingCUDService {
                     }
                     try {
                         if (imgs.getMainImage() != null) {
-                            s3Service.deletePublic(s3Service.extractKey(imgs.getMainImage()));
+                            s3Service.deletePrivate(imgs.getMainImage());
                         }
                         Arrays.asList(imgs.getAux1(), imgs.getAux2(), imgs.getAux3(), imgs.getAux4())
                                 .forEach(url -> {
                                     if (url != null) {
                                         try {
-                                            s3Service.deletePublic(s3Service.extractKey(url));
+                                            s3Service.deletePrivate(url);
                                         } catch (Exception ex) {
                                             log.error("Error deleting aux image", ex);
                                         }

--- a/src/main/java/Marketplace/services/impl/UserServiceImpl.java
+++ b/src/main/java/Marketplace/services/impl/UserServiceImpl.java
@@ -81,7 +81,7 @@ public class UserServiceImpl implements UserService {
                 for (String url : images) {
                     if (url != null) {
                         try {
-                            s3Service.deletePublic(s3Service.extractKey(url));
+                            s3Service.deletePrivate(url);
                         } catch (Exception ex) {
                             log.error("Error deleting user image", ex);
                         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -41,7 +41,6 @@ cors.max.age=${CORS_MAX_AGE:3600}
 # AWS / S3
 # -------------------------------
 aws.region=${AWS_REGION:us-east-1}
-s3.public-bucket=${S3_PUBLIC_BUCKET:privium-photos}
 s3.private-bucket=${S3_PRIVATE_BUCKET:privium-private}
 s3.presign.ttl-minutes=${S3_PRESIGN_TTL_MINUTES:10}
 


### PR DESCRIPTION
## Summary
- Save listing photos in the private S3 bucket
- Return pre-signed URLs for listing images
- Clean up private images when listings or users are removed
- Remove obsolete public S3 bucket methods and config

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cd84a17ec8330b1fca906532eef77